### PR TITLE
Auto-update yt-dlp via scheduled PR instead of manual releases

### DIFF
--- a/.github/workflows/yt-dlp-check.yml
+++ b/.github/workflows/yt-dlp-check.yml
@@ -1,7 +1,7 @@
 name: yt-dlp Update Check
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 22 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/yt-dlp-check.yml
+++ b/.github/workflows/yt-dlp-check.yml
@@ -18,25 +18,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          cache: pip
 
       - name: Install dependencies
-        run: pip install requests
+        run: pip install -r requirements-dev.txt
 
       - name: Check yt-dlp version and bump if needed
-        id: bump
-        run: python build.py --ytdl --no-push --ver_update
+        run: python build.py --ytdl
 
       - name: Create Pull Request
-        if: steps.bump.outputs.updated == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@main
         with:
-          commit-message: Upgrade yt-dlp
-          title: Upgrade yt-dlp
-          body: >
-            Automated: yt-dlp has a newer commit upstream than what's bundled in the
-            latest Music Caster release. This bumps the patch version in
-            `src/meta.py`, `app/package.json`, and the build files, and adds a
-            changelog entry.
+          commit-message: "Bump version; new yt-dlp"
+          title: "Shipping new yt-dlp requires version bump"
+          body: "Shipping new yt-dlp requires version bump"
           branch: auto/yt-dlp-upgrade
           delete-branch: true

--- a/.github/workflows/yt-dlp-check.yml
+++ b/.github/workflows/yt-dlp-check.yml
@@ -1,0 +1,38 @@
+name: yt-dlp Update Check
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Check yt-dlp version and bump if needed
+        id: bump
+        run: python build.py --ytdl --no-push --ver_update
+
+      - name: Create Pull Request
+        if: steps.bump.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Upgrade yt-dlp
+          title: Upgrade yt-dlp
+          body: >
+            Automated: yt-dlp has a newer commit upstream than what's bundled in the
+            latest Music Caster release. This bumps the patch version in
+            `src/meta.py`, `app/package.json`, and the build files, and adds a
+            changelog entry.
+          branch: auto/yt-dlp-upgrade
+          delete-branch: true

--- a/.github/workflows/yt-dlp-check.yml
+++ b/.github/workflows/yt-dlp-check.yml
@@ -31,6 +31,5 @@ jobs:
         with:
           commit-message: "Bump version; new yt-dlp"
           title: "Shipping new yt-dlp requires version bump"
-          body: "Shipping new yt-dlp requires version bump"
           branch: auto/yt-dlp-upgrade
           delete-branch: true

--- a/.github/workflows/yt-dlp-check.yml
+++ b/.github/workflows/yt-dlp-check.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/build.py
+++ b/build.py
@@ -264,7 +264,6 @@ def upgrade_yt_dlp():
              f.read()))
         f.seek(0)
         f.write(content)
-    update_versions(new_version)
 
 
 if __name__ == '__main__':

--- a/build.py
+++ b/build.py
@@ -234,11 +234,9 @@ def test(title, fn, assert_statement=False):
         raise _e
 
 
-def upgrade_yt_dlp(push=True):
-    """Bump Music Caster's version if yt-dlp has a newer commit than our latest release.
-
-    Returns the new version string if a bump happened, else None.
-    """
+def upgrade_yt_dlp():
+    """Bump Music Caster's version if yt-dlp has a newer commit than our latest release."""
+    import json
     import requests
 
     latest_ytdl = 'https://api.github.com/repos/yt-dlp/yt-dlp/commits/master'
@@ -249,28 +247,17 @@ def upgrade_yt_dlp(push=True):
     mc_publish = requests.get(latest_mc).json()['published_at']
     mc_release_time = datetime.strptime(mc_publish, '%Y-%m-%dT%H:%M:%SZ')
     if mc_release_time >= yt_dlp_release_time:  # latest yt-dlp already used in latest MC
-        return None
+        return
     print('New yt-dlp commit found, bumping Music Caster version')
-    # if yt-dlp was released after the latest music-caster, update version and publish
-    maj, _min, fix = VERSION.split('.')
-    new_version = f'{maj}.{_min}.{int(fix) + 1}'
-    with open(SRC_DIR / 'meta.py', 'r+', encoding='utf-8', newline='\n') as f:
-        # VERSION = latest_version = '5.0.0'
-        new_txt = f.read().replace(
-            f"VERSION = latest_version = '{VERSION}'",
-            f"VERSION = latest_version = '{new_version}'",
-        )
+    # meta.VERSION is being deprecated; app/package.json is the source of truth
+    package_json = script_dir / 'app' / 'package.json'
+    with open(package_json, 'r+', encoding='utf-8', newline='\n') as f:
+        content = f.read()
+        current_version = json.loads(content)['version']
+        maj, _min, fix = current_version.split('.')
+        new_version = f'{maj}.{_min}.{int(fix) + 1}'
         f.seek(0)
-        f.write(new_txt)
-    # app/package.json is what tauri.conf.json's "version" points to and is what the
-    # Tauri release pipeline actually ships, so keep it in sync with meta.py's VERSION
-    with open(script_dir / 'app' / 'package.json', 'r+', encoding='utf-8', newline='\n') as f:
-        new_txt = f.read().replace(
-            f'"version": "{VERSION}"',
-            f'"version": "{new_version}"',
-        )
-        f.seek(0)
-        f.write(new_txt)
+        f.write(content.replace(f'"version": "{current_version}"', f'"version": "{new_version}"'))
     with open(CHANGELOG_FILE, 'r+', encoding='utf-8', newline='\n') as f:
         content = ''.join(
             (f.readline(), f'\n{new_version}\n- Upgrade yt-dlp\n',
@@ -278,16 +265,6 @@ def upgrade_yt_dlp(push=True):
         f.seek(0)
         f.write(content)
     update_versions(new_version)
-    if push:
-        # commit and push change
-        from git import Repo
-
-        repo = Repo('.git')
-        repo.git.add(update=True)
-        repo.index.commit('Upgraded yt-dlp')
-        origin = repo.remote(name='origin')
-        origin.push()
-    return new_version
 
 
 if __name__ == '__main__':
@@ -381,13 +358,6 @@ if __name__ == '__main__':
         help='version++ if new youtube-dl available',
     )
     parser.add_argument(
-        '--no-push',
-        default=False,
-        action='store_true',
-        help='with --ytdl, bump version/changelog files without git commit+push '
-             '(for CI to turn into a PR)',
-    )
-    parser.add_argument(
         '--ci',
         default=False,
         action='store_true',
@@ -424,11 +394,8 @@ if __name__ == '__main__':
         print('Building Music Caster')
 
     if args.ytdl:
-        new_version = upgrade_yt_dlp(push=not args.no_push)
-        github_output = os.environ.get('GITHUB_OUTPUT')
-        if github_output:
-            with open(github_output, 'a', encoding='utf-8') as f:
-                f.write(f"updated={'true' if new_version else 'false'}\n")
+        upgrade_yt_dlp()
+        sys.exit(0)
     else:
         update_versions(VERSION)
     print('Updated versions of build files')

--- a/build.py
+++ b/build.py
@@ -234,7 +234,13 @@ def test(title, fn, assert_statement=False):
         raise _e
 
 
-def upgrade_yt_dlp():
+def upgrade_yt_dlp(push=True):
+    """Bump Music Caster's version if yt-dlp has a newer commit than our latest release.
+
+    Returns the new version string if a bump happened, else None.
+    """
+    import requests
+
     latest_ytdl = 'https://api.github.com/repos/yt-dlp/yt-dlp/commits/master'
     latest_mc = 'https://api.github.com/repos/elibroftw/music-caster/releases/latest'
     yt_dlp_master = requests.get(latest_ytdl).json()
@@ -242,27 +248,37 @@ def upgrade_yt_dlp():
     yt_dlp_release_time = datetime.strptime(ytdl_publish, '%Y-%m-%dT%H:%M:%SZ')
     mc_publish = requests.get(latest_mc).json()['published_at']
     mc_release_time = datetime.strptime(mc_publish, '%Y-%m-%dT%H:%M:%SZ')
-    if mc_release_time < yt_dlp_release_time:  # latest yt-dlp not used in latest MC
-        print('New YouTube-dl found, updating Music Caster version')
-        # if youtube-dl was released after the latest music-caster, update version and publish
-        maj, _min, fix = VERSION.split('.')
-        fix = int(fix) + 1
-        new_version = f'{maj}.{_min}.{fix}'
-        with open('meta.py', 'r+', encoding='utf-8', newline='\n') as f:
-            # VERSION = latest_version = '5.0.0'
-            new_txt = f.read().replace(
-                f"VERSION = latest_version = '{VERSION}'",
-                f"VERSION = latest_version = '{new_version}'",
-            )
-            f.seek(0)
-            f.write(new_txt)
-        with open(CHANGELOG_FILE, 'r+', encoding='utf-8', newline='\n') as f:
-            content = ''.join(
-                (f.readline(), f'\n{VERSION}\n- Upgrade dependencies\n',
-                 f.read()))
-            f.seek(0)
-            f.write(content)
-        update_versions(new_version)
+    if mc_release_time >= yt_dlp_release_time:  # latest yt-dlp already used in latest MC
+        return None
+    print('New yt-dlp commit found, bumping Music Caster version')
+    # if yt-dlp was released after the latest music-caster, update version and publish
+    maj, _min, fix = VERSION.split('.')
+    new_version = f'{maj}.{_min}.{int(fix) + 1}'
+    with open(SRC_DIR / 'meta.py', 'r+', encoding='utf-8', newline='\n') as f:
+        # VERSION = latest_version = '5.0.0'
+        new_txt = f.read().replace(
+            f"VERSION = latest_version = '{VERSION}'",
+            f"VERSION = latest_version = '{new_version}'",
+        )
+        f.seek(0)
+        f.write(new_txt)
+    # app/package.json is what tauri.conf.json's "version" points to and is what the
+    # Tauri release pipeline actually ships, so keep it in sync with meta.py's VERSION
+    with open(script_dir / 'app' / 'package.json', 'r+', encoding='utf-8', newline='\n') as f:
+        new_txt = f.read().replace(
+            f'"version": "{VERSION}"',
+            f'"version": "{new_version}"',
+        )
+        f.seek(0)
+        f.write(new_txt)
+    with open(CHANGELOG_FILE, 'r+', encoding='utf-8', newline='\n') as f:
+        content = ''.join(
+            (f.readline(), f'\n{new_version}\n- Upgrade yt-dlp\n',
+             f.read()))
+        f.seek(0)
+        f.write(content)
+    update_versions(new_version)
+    if push:
         # commit and push change
         from git import Repo
 
@@ -271,6 +287,7 @@ def upgrade_yt_dlp():
         repo.index.commit('Upgraded yt-dlp')
         origin = repo.remote(name='origin')
         origin.push()
+    return new_version
 
 
 if __name__ == '__main__':
@@ -364,6 +381,13 @@ if __name__ == '__main__':
         help='version++ if new youtube-dl available',
     )
     parser.add_argument(
+        '--no-push',
+        default=False,
+        action='store_true',
+        help='with --ytdl, bump version/changelog files without git commit+push '
+             '(for CI to turn into a PR)',
+    )
+    parser.add_argument(
         '--ci',
         default=False,
         action='store_true',
@@ -400,7 +424,11 @@ if __name__ == '__main__':
         print('Building Music Caster')
 
     if args.ytdl:
-        upgrade_yt_dlp()
+        new_version = upgrade_yt_dlp(push=not args.no_push)
+        github_output = os.environ.get('GITHUB_OUTPUT')
+        if github_output:
+            with open(github_output, 'a', encoding='utf-8') as f:
+                f.write(f"updated={'true' if new_version else 'false'}\n")
     else:
         update_versions(VERSION)
     print('Updated versions of build files')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-GitPython~=3.1
+requests~=2.28
 autopep8
 requirements-parser
 # pyinstaller dependencies


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/yt-dlp-check.yml`: runs daily (and on-demand via `workflow_dispatch`), checks whether yt-dlp has a newer upstream commit than Music Caster's latest release, and if so opens a PR bumping the version + changelog instead of pushing directly.
- Fixes three bugs in `upgrade_yt_dlp()` (build.py) that made it silently unusable: a `requests` call with no import in scope at that point in execution, a `meta.py` path that no longer matched its real location at `src/meta.py`, and a changelog entry stamped with the old version instead of the new one.
- `upgrade_yt_dlp()` now bumps **both** `src/meta.py` and `app/package.json` — these had no sync mechanism before, and `app/package.json` is what `tauri.conf.json` points to (i.e. what the real Tauri/winget release pipeline ships).
- New `--no-push` flag lets CI bump the version files without committing/pushing directly; combined with the existing `--ver_update` flag, CI calls `python build.py --ytdl --no-push --ver_update` and reads an `updated=true|false` output to decide whether to open a PR.

## Test plan
- [x] Ran the bump logic locally against live data (yt-dlp's real latest commit is currently ahead of MC's real latest release) and confirmed all 5 files update correctly, then reverted the file changes to isolate the code fix in the commit.
- [x] Verified the `GITHUB_OUTPUT` write path locally.
- [x] Validated the workflow YAML structure (triggers, steps, conditional).
- [x] Live end-to-end test on a fork: pushed the branch, enabled Actions, ran `workflow_dispatch` — it correctly detected the outdated version and opened a real PR with the expected 5-file diff. Closed/cleaned up that test PR afterward.
- [ ] Confirm on merge that the daily cron fires as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)